### PR TITLE
DEF0825509 : Pipeline name containing "&" not URL-encoded when fetched from GitHub context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,6 @@ typings/
 
 # TernJS port file
 .tern-port
+
+# ide files
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,3 @@ typings/
 
 # TernJS port file
 .tern-port
-
-# ide files
-.idea/

--- a/dist/index.js
+++ b/dist/index.js
@@ -10750,8 +10750,8 @@ const main = async () => {
             }
 
             let buildNumber = changeDetails.build_number;
-            let pipelineName = encodeURIComponent(changeDetails.pipeline_name);
-            let stageName = encodeURIComponent(changeDetails.stage_name);
+            let pipelineName = changeDetails.pipeline_name;
+            let stageName = changeDetails.stage_name;
             let attemptNumber = changeDetails.attempt_number;
 
             //Checking if any input values are empty and defaulting to the current Stage, Pipeline Name, Build Number
@@ -10765,6 +10765,9 @@ const main = async () => {
                 pipelineName = `${githubContext.repository}` + '/' + `${githubContext.workflow}`;
             if (stageName == null || stageName == '')
                 stageName = `${githubContext.job}`;
+
+            pipelineName = encodeURIComponent(pipelineName);
+            stageName = encodeURIComponent(stageName);
 
             console.log("buildNumber => " + buildNumber + ", pipelineName => " + pipelineName + ", stageName => " + stageName + ", attemptNumber => " + attemptNumber);
 

--- a/src/main.js
+++ b/src/main.js
@@ -62,8 +62,8 @@ const main = async () => {
             }
 
             let buildNumber = changeDetails.build_number;
-            let pipelineName = encodeURIComponent(changeDetails.pipeline_name);
-            let stageName = encodeURIComponent(changeDetails.stage_name);
+            let pipelineName = changeDetails.pipeline_name;
+            let stageName = changeDetails.stage_name;
             let attemptNumber = changeDetails.attempt_number;
 
             //Checking if any input values are empty and defaulting to the current Stage, Pipeline Name, Build Number
@@ -77,6 +77,9 @@ const main = async () => {
                 pipelineName = `${githubContext.repository}` + '/' + `${githubContext.workflow}`;
             if (stageName == null || stageName == '')
                 stageName = `${githubContext.job}`;
+
+            pipelineName = encodeURIComponent(pipelineName);
+            stageName = encodeURIComponent(stageName);
 
             console.log("buildNumber => " + buildNumber + ", pipelineName => " + pipelineName + ", stageName => " + stageName + ", attemptNumber => " + attemptNumber);
 


### PR DESCRIPTION
Description : 
In the servicenow-devops-get-change GitHub Action, when the pipeline name is not explicitly passed as an input parameter, the action fetches the current pipeline name from the GitHub context. In this flow, the pipeline name is not being URL-encoded before being used in the API call. If the pipeline name contains special characters such as "&", the request fails.
